### PR TITLE
CD에서 Chart.yamle 파일생성 방지 

### DIFF
--- a/.github/workflows/CD.yaml
+++ b/.github/workflows/CD.yaml
@@ -19,7 +19,7 @@ jobs:
 
             - name: Update appVersion
               run: |
-                sed -ie "s/appVersion.*/appVersion: ${{ github.event.release.tag_name }}/g" chart/Chart.yaml
+                sed -i "s/appVersion.*/appVersion: ${{ github.event.release.tag_name }}/g" chart/Chart.yaml
                 cat chart/Chart.yaml
               shell: bash
 


### PR DESCRIPTION
sed의 -ie option에서 -i뒤에 e가 백업 파일의 접미사를 의미해 e가 붙은 백업 파일이 생성되는 이슈였습니다.

-ie -> -i
close #79 
