### PR TITLE
Update) 스터디 모집완료 로직 문제 관련 수정

### DIFF
--- a/templates/recruits/index.html
+++ b/templates/recruits/index.html
@@ -57,39 +57,37 @@
             <ul id="recruit-list"
                 class="grid {% if user.is_authenticated %}grid-cols-1 lg:grid-cols-2{% else %}grid-cols-2 lg:grid-cols-3{% endif %} gap-8 pt-8">
                 {% for recruit in recruits %}
-                    {% if recruit.members.count < recruit.total_seats and recruit.study.status != 3 and recruit.study.status != 4 %}
-                        <li class="p-2">
-                            <a href="{% url 'recruits:recruit_detail' recruit.id %}">
-                                <div class="w-full">
-                                    <h3 class="text-xl">{{ recruit.title }}</h3>
-                                    <p class="pt-1">{{ recruit.creator }}</p>
-                                </div>
-                                <div class="flex justify-between pt-2 text-sm">
-                                    <span class="text-neutral-500">{{ recruit.deadline|date:'Y.m.d' }}</span>
-                                    <span>{{ recruit.members.count }}/{{ recruit.total_seats }}</span>
-                                </div>
-                            </a>
-                            <ul class="flex pt-1 flex-wrap">
-                                {% for tag in recruit.tags.all %}
-                                    <li class="mr-2 mb-2 last:m-0 text-sm">
-                                        <a href="?tag={{ tag.name }}" class="bg-neutral-200 px-2">{{ tag.name }}</a>
-                                    </li>
-                                {% endfor %}
-                            </ul>
-                            <div class="pt-1">
-                                <span class="text-sm">{{ recruit.like_users.count }}</span>
-                                {% if recruit in liked_studies %}
-                                    <a href="{% url 'recruits:unlike_recruit' recruit.pk %}">
-                                        <i class="fa-solid fa-heart text-red-400"></i>
-                                    </a>
-                                {% else %}
-                                    <a href="{% url 'recruits:like_recruit' recruit.pk %}">
-                                        <i class="fa-solid fa-heart"></i>
-                                    </a>
-                                {% endif %}
+                    <li class="p-2">
+                        <a href="{% url 'recruits:recruit_detail' recruit.id %}">
+                            <div class="w-full">
+                                <h3 class="text-xl">{{ recruit.title }}</h3>
+                                <p class="pt-1">{{ recruit.creator }}</p>
                             </div>
-                        </li>
-                    {% endif %}
+                            <div class="flex justify-between pt-2 text-sm">
+                                <span class="text-neutral-500">{{ recruit.deadline|date:'Y.m.d' }}</span>
+                                <span>{{ recruit.members.count }}/{{ recruit.total_seats }}</span>
+                            </div>
+                        </a>
+                        <ul class="flex pt-1 flex-wrap">
+                            {% for tag in recruit.tags.all %}
+                                <li class="mr-2 mb-2 last:m-0 text-sm">
+                                    <a href="?tag={{ tag.name }}" class="bg-neutral-200 px-2">{{ tag.name }}</a>
+                                </li>
+                            {% endfor %}
+                        </ul>
+                        <div class="pt-1">
+                            <span class="text-sm">{{ recruit.like_users.count }}</span>
+                            {% if recruit in liked_studies %}
+                                <a href="{% url 'recruits:unlike_recruit' recruit.pk %}">
+                                    <i class="fa-solid fa-heart text-red-400"></i>
+                                </a>
+                            {% else %}
+                                <a href="{% url 'recruits:like_recruit' recruit.pk %}">
+                                    <i class="fa-solid fa-heart"></i>
+                                </a>
+                            {% endif %}
+                        </div>
+                    </li>
                 {% endfor %}
             </ul>
         </div>

--- a/templates/studies/index.html
+++ b/templates/studies/index.html
@@ -26,7 +26,7 @@
             <p class="text-xl p-2">나의 모집글</p>
             <div class="scroll_invisible h-[275px] overflow-y-scroll">
                 {% for my_recruit in my_recruits %}
-                    <div class="shadow-md w-[90%] p-1 mb-1 mx-auto">
+                    <div class=" w-[90%] p-1 mb-1 mx-auto">
                         <a class="block text-xl truncate w-[100px]"
                            href="{% url "recruits:recruit_detail" my_recruit.id %}">{{ my_recruit.title }}</a>
                         <div class="flex justify-between">
@@ -74,7 +74,7 @@
             <div class="scroll_invisible h-[275px] overflow-y-scroll">
                 {% for like_recruit in like_recruits %}
                     {% if like_recruit.creator != user %}
-                        <div class="shadow-md w-[90%] p-1 mb-1 mx-auto">
+                        <div class=" w-[90%] p-1 mb-1 mx-auto">
                             <a class="text-xl truncate w-[100px]"
                                href="{% url "recruits:recruit_detail" like_recruit.id %}">{{ like_recruit.title }}</a>
                             <div class="flex justify-between">
@@ -97,7 +97,7 @@
             <p class="text-4xl p-2">나의 스터디</p>
             <div class="flex flex-row overflow-hidden w-full min-w-[250px] h-[300px] overflow-x-scroll pb-4">
                 {% for my_study in my_studies %}
-                    <div class="shadow-md mx-3 p-1 min-w-[250px] h-[100px] hover:h-[250px] overflow-hidden">
+                    <div class=" mx-3 p-1 min-w-[250px] h-[100px] hover:h-[250px] overflow-hidden">
                         <div class="relative pt-2 flex items-end">
                             <a class="text-2xl truncate w-[100px]"
                                href="{% url 'manager:study_detail' my_study.id %}">{{ my_study.title }}</a>
@@ -154,7 +154,7 @@
             <p class="text-4xl p-2">참여 스터디</p>
             <div class="flex flex-row overflow-hidden w-full min-w-[250px] h-[250px] overflow-x-scroll pb-4">
                 {% for in_study in in_studies %}
-                    <div class="shadow-md mx-3 p-1 min-w-[250px] h-[100px] hover:h-[150px] overflow-hidden">
+                    <div class=" mx-3 p-1 min-w-[250px] h-[100px] hover:h-[150px] overflow-hidden">
                         <div class="relative pt-2 flex items-end">
                             <a class="text-2xl truncate w-[100px]"
                                href="{% url 'manager:study_detail' in_study.id %}">{{ in_study.title }}</a>


### PR DESCRIPTION
recruit.members 필드는 스터디신청인원이 아닌 스터디신청 확정후 추가되는 멤버라서 신청인원자체가 제한되지는 않는걸로 확인했습니다.

유빈님 의견대로 메인페이지에서 쿼리셋을 불러올때 조건문을 걸어서 종료되거나 완료된 스터디와 인원이 가득한 스터디관련 모집글을 제외하게 작성했습니다.

모집글에서 신청이와서 멤버를 추가할때 모집인원과 추가하고나서의 확정멤버가 같을경우 스터디의 상태를 in progress로 변경되도록 작성했습니다.

close #280 