### PR TITLE
Update) 스터디 입장,퇴장 알림 수정

### DIFF
--- a/templates/chat/room.html
+++ b/templates/chat/room.html
@@ -70,6 +70,7 @@
 {% endblock content %}
 {% block include_js %}
     {{ room.id|json_script:"room-id" }}
+    {{ room.get_category_display|json_script:"room-title" }}
     {{ room.study.id|json_script:"study-id" }}
     {{ user.username|json_script:"request-user" }}
 {% endblock include_js %}
@@ -95,6 +96,9 @@
 
             const roomId = JSON.parse(
                 document.getElementById('room-id').textContent
+            );
+            const roomTitle = JSON.parse(
+                document.getElementById('room-title').textContent
             );
             const studyId = JSON.parse(
                 document.getElementById('study-id').textContent
@@ -142,6 +146,7 @@
             
                 onopen() {
                     console.log("Chat socket opened");
+                    init_chatroom(requestUser,roomTitle,studyId);
                     this.retry = 0;
                 },
 
@@ -268,14 +273,29 @@
             chat_box.scrollTop = chat_box.scrollHeight;      
             
         })
+
+        function init_chatroom(username,chat_name,study_id) {
+        var notice = {
+        "content" :  username + "(이)가 " + chat_name + " 채팅방에 접속했습니다.",
+        "study_id" : study_id,
+        "username" : username,
+        "db_save" : false
+        };
+        notice_socket.send(JSON.stringify(notice));
+        };
     </script>
 {% endblock script %}
 {% block websocket %}
+    window.onbeforeunload = function() {
+    out_chatroom('{{ user.username }}','{{ room.get_category_display }}','{{ room.study.id }}');
+    return null;
+    };
     function out_chatroom(username,chat_name,study_id) {
     var notice = {
-    "content" :  username + "(이)가 " + chat_name + "을 나갔습니다.",
+    "content" :  username + "(이)가 " + chat_name + " 채팅방을 나갔습니다.",
     "study_id" : study_id,
-    "username" : username
+    "username" : username,
+    "db_save" : false
     };
     notice_socket.send(JSON.stringify(notice));
     };

--- a/templates/studies/detail.html
+++ b/templates/studies/detail.html
@@ -260,13 +260,3 @@
         });
     </script>
 {% endblock script %}
-{% block websocket %}
-    function init_chatroom(username,chat_name,study_id) {
-    var notice = {
-    "content" :  username + "(이)가 " + chat_name + "에 접속했습니다.",
-    "study_id" : study_id,
-    "username" : username
-    };
-    notice_socket.send(JSON.stringify(notice));
-    };
-{% endblock websocket %}


### PR DESCRIPTION
스터디 입장,퇴장 알림은 db 저장 안되게 수정 ( 알림양이 많을 것 같아서 수정 하였고, 추후에는 채팅방에 출력되도록 수정할 것이기 때문에) 

스터디 입장알림 - 채팅룸 웹소켓 연결시 알림 전송

스터디 퇴장알림 - 새로고침,뒤로가기,브라우저 종료등 페이지를 나가면 알림전송( 웹소켓 연결 끊길 때 하고싶었는데 연결이 끊기는것 때문인지 onclose에 알림전송함수를 넣어도 실해이 안됨)

close #308 